### PR TITLE
Release 1.3.3 for Minecraft 1.19 - FD 1.1.2 (1.19.X compat) 

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -36,7 +36,7 @@
   "depends": {
     "fabricloader": ">=0.14.7",
     "fabric": ">=0.56.0+1.19",
-    "minecraft": "1.19"
+    "minecraft": "~1.19"
   },
   "suggests": {
   }


### PR DESCRIPTION
Add compatibility for all 1.19.X versions.