### PR TITLE
Fix the Create/EMI/Farmers Delight bug

### DIFF
--- a/src/main/resources/data/farmersdelight/recipes/create/filling/chocolate_pie.json
+++ b/src/main/resources/data/farmersdelight/recipes/create/filling/chocolate_pie.json
@@ -11,7 +11,7 @@
       "item": "farmersdelight:pie_crust"
     },
     {
-      "fluidTag": "c:chocolates",
+      "fluidTag": "c:chocolate",
       "amount": 500
     }
   ],

--- a/src/main/resources/data/farmersdelight/recipes/create/filling/chocolate_pie.json
+++ b/src/main/resources/data/farmersdelight/recipes/create/filling/chocolate_pie.json
@@ -12,7 +12,7 @@
     },
     {
       "fluidTag": "c:chocolate",
-      "amount": 500
+      "amount": 40500
     }
   ],
   "results": [


### PR DESCRIPTION
I found the bug! It's the Farmer's Delight Create-compat [chocolate pie filling recipe](https://github.com/newhoryzon/farmers-delight-fabric/blob/master/src/main/resources/data/farmersdelight/recipes/create/filling/chocolate_pie.json) - the fluid tag `c:chocolates` isn't used in Create, it's `c:chocolate` instead, so switching to the proper tag should stop it from getting index out-of-bounds issues!