### PR TITLE
Make StewItem derivatives only take 1 item at a time when eaten

### DIFF
--- a/src/main/java/com/nhoryzon/mc/farmersdelight/mixin/ItemMixin.java
+++ b/src/main/java/com/nhoryzon/mc/farmersdelight/mixin/ItemMixin.java
@@ -1,0 +1,32 @@
+package com.nhoryzon.mc.farmersdelight.mixin;
+
+import com.nhoryzon.mc.farmersdelight.FarmersDelightMod;
+import net.minecraft.item.Item;
+import net.minecraft.item.StewItem;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
+import org.apache.commons.lang3.StringUtils;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.List;
+
+@Mixin(Item.class)
+public abstract class ItemMixin {
+
+    @Inject(method = "getMaxCount", at = @At("RETURN"), cancellable = true)
+    public void getMaxCount(CallbackInfoReturnable<Integer> cir) {
+        if (((Object) this) instanceof StewItem stewItem && FarmersDelightMod.CONFIG.isEnableStackableSoupSize()) {
+            Identifier itemId = Registry.ITEM.getId(stewItem);
+            String strItemId = itemId != null ? itemId.toString() : StringUtils.EMPTY;
+            boolean isOverrideAllSoupItem = FarmersDelightMod.CONFIG.isOverrideAllSoupItems();
+            List<String> soupItemList = FarmersDelightMod.CONFIG.getSoupItemList();
+            if ((isOverrideAllSoupItem && !soupItemList.contains(strItemId)) || (!isOverrideAllSoupItem && soupItemList.contains(strItemId))) {
+                cir.setReturnValue(16);
+            }
+        }
+    }
+
+}

--- a/src/main/resources/farmersdelight.mixins.json
+++ b/src/main/resources/farmersdelight.mixins.json
@@ -4,36 +4,37 @@
   "compatibilityLevel": "JAVA_16",
   "refmap": "farmers-delight-fabric-refmap.json",
   "mixins": [
-    "AttachedStemBlockOnRichSoilFarmlandMixin",
-    "CampfireBaleMixin",
-    "ChickenEntityBreedingMixin",
-    "CropBlockOnRichSoilFarmlandMixin",
-    "DeadBushBlockOnRichSoilMixin",
-    "EnchantmentEnhancementMixin",
-    "EnchantmentHelperEnhancementMixin",
-    "LivingEntityBackstabbingEnchantmentMixin",
-    "LivingEntityKnockBackMixin",
-    "LivingEntityOnUseItemFinishMixin",
-    "MigrationBlockEntityMixin",
-    "MigrationBlockRegistryMixin",
-    "MigrationItemStackMixin",
-    "PigEntityBreedingMixin",
-    "PlantBlockOnRichSoilMixin",
-    "PlayerEntityAttackWithSkilletMixin",
-    "StemBlockOnRichSoilFarmlandMixin",
-    "StewItemMixin",
-    "accessors.DispenserBehaviorsAccessorMixin",
-    "accessors.ParrotsTamingIngredientsAccessorMixin",
-    "accessors.PlayerExhaustionAccessorMixin",
-    "accessors.RecipeManagerAccessorMixin",
-    "accessors.StructurePoolAccessorMixin"
+	"AttachedStemBlockOnRichSoilFarmlandMixin",
+	"CampfireBaleMixin",
+	"ChickenEntityBreedingMixin",
+	"CropBlockOnRichSoilFarmlandMixin",
+	"DeadBushBlockOnRichSoilMixin",
+	"EnchantmentEnhancementMixin",
+	"EnchantmentHelperEnhancementMixin",
+	"ItemMixin",
+	"LivingEntityBackstabbingEnchantmentMixin",
+	"LivingEntityKnockBackMixin",
+	"LivingEntityOnUseItemFinishMixin",
+	"MigrationBlockEntityMixin",
+	"MigrationBlockRegistryMixin",
+	"MigrationItemStackMixin",
+	"PigEntityBreedingMixin",
+	"PlantBlockOnRichSoilMixin",
+	"PlayerEntityAttackWithSkilletMixin",
+	"StemBlockOnRichSoilFarmlandMixin",
+	"StewItemMixin",
+	"accessors.DispenserBehaviorsAccessorMixin",
+	"accessors.ParrotsTamingIngredientsAccessorMixin",
+	"accessors.PlayerExhaustionAccessorMixin",
+	"accessors.RecipeManagerAccessorMixin",
+	"accessors.StructurePoolAccessorMixin"
   ],
   "client": [
-    "CanvasSignEditScreenMixin",
-    "InGameHudMixin"
+	"CanvasSignEditScreenMixin",
+	"InGameHudMixin"
   ],
   "injectors": {
-    "defaultRequire": 1
+	"defaultRequire": 1
   },
   "minVersion": "0.8"
 }


### PR DESCRIPTION
Fixes bugs #118 and #142.

Technical stuff:
- Moves StewItemMixin functionality to ItemMixin because it only affected the Item class.
- Makes a new StewItemMixin that overrides the `finishUsing` method to make it use the `ItemUsage.exchangeStack` utility function, similar to the BucketItem class from vanilla minecraft.
- I figured that `StewItemMixin.finishUsing` doesn't need to check if the config makes soup items stackable as the mixin doesn't affect anything if that config is turned off, but you can add an if statement to check if the config is enabled if you would like.