### PR TITLE
Fix StackOverflowException when calling ItemStackInventory#IsEmpty

### DIFF
--- a/src/main/java/com/nhoryzon/mc/farmersdelight/entity/block/inventory/ItemStackInventory.java
+++ b/src/main/java/com/nhoryzon/mc/farmersdelight/entity/block/inventory/ItemStackInventory.java
@@ -47,7 +47,7 @@ public interface ItemStackInventory extends Inventory {
 
     @Override
     default boolean isEmpty() {
-        return getItems().stream().anyMatch(stack -> !isEmpty());
+        return getItems().stream().anyMatch(stack -> !stack.isEmpty());
     }
 
     @Override


### PR DESCRIPTION
When `isEmpty` is called on a Farmer's Delight inventory, it recursively calls itself, leading to a StackOverflowException.

This can be reproduced by attaching a hopper to a Cooking Pot and attempting to insert items using it.

This PR fixes the bug by properly delegating to `ItemStack#isEmpty` instead of the ItemStackInventory's own `isEmpty`.