### PR TITLE
Fix a crash having to do with contained foods.

### DIFF
--- a/src/main/java/com/nhoryzon/mc/farmersdelight/client/screen/CookingPotScreen.java
+++ b/src/main/java/com/nhoryzon/mc/farmersdelight/client/screen/CookingPotScreen.java
@@ -70,10 +70,12 @@ public class CookingPotScreen extends HandledScreen<CookingPotScreenHandler> {
                 }
                 meal.getItem().appendTooltip(meal, handler.tileEntity.getWorld(), tooltip, TooltipContext.Default.BASIC);
 
-                ItemStack containerItem = handler.tileEntity.getMealContainer();
-                String container = !containerItem.isEmpty() ? containerItem.getItem().getName().getString() : "";
+                if (handler.tileEntity.getMealContainerIsValid()) {
+                    ItemStack containerItem = handler.tileEntity.getMealContainer();
+                    String container = !containerItem.isEmpty() ? containerItem.getItem().getName().getString() : "";
 
-                tooltip.add(FarmersDelightMod.i18n("container.cooking_pot.served_on", container).formatted(Formatting.GRAY));
+                    tooltip.add(FarmersDelightMod.i18n("container.cooking_pot.served_on", container).formatted(Formatting.GRAY));
+                }
 
                 context.drawTooltip(textRenderer, tooltip, mouseX, mouseY);
             } else {

--- a/src/main/java/com/nhoryzon/mc/farmersdelight/entity/block/CookingPotBlockEntity.java
+++ b/src/main/java/com/nhoryzon/mc/farmersdelight/entity/block/CookingPotBlockEntity.java
@@ -229,6 +229,11 @@ public class CookingPotBlockEntity extends SyncedBlockEntity implements CookingP
         return Optional.empty();
     }
 
+    public boolean getMealContainerIsValid() {
+        if ((mealContainer.isEmpty() || !getMeal().getItem().hasRecipeRemainder())) return false;
+        return true;
+    }
+
     public ItemStack getMealContainer() {
         if (!mealContainer.isEmpty()) {
             return mealContainer;


### PR DESCRIPTION
By the way #218 is valid in 1.4.3.

Check if the item  even _has_ a recipe remainder or container before ~~trying to display it~~ crashing it.

Resolve #218

Thanks @Zifiv for your hard work. I absolutely love this mod!